### PR TITLE
feat: update the notation to jis algebraic

### DIFF
--- a/components/cez/board_ai.tsx
+++ b/components/cez/board_ai.tsx
@@ -23,7 +23,15 @@ interface GameStats {
 const moveToNotation = (move: Move): string => {
   const from = String.fromCharCode(97 + move.from.x) + (8 - move.from.y);
   const to = String.fromCharCode(97 + move.to.x) + (8 - move.to.y);
-  return `${from}-${to}`;
+  const move_type = (move.capture == null) ? '>' : 'x';
+  if (move.to.x == move.from.x) {
+    return `${from}${move_type}${8 - move.to.y}`
+  }
+  else if (move.to.y == move.from.y) {
+    return `${from}${move_type}${String.fromCharCode(97 + move.to.x)}`
+  } else {
+    return '<invalid>'
+  }
 }
 
 export const CezBoardAI: React.FC<Props> = ({ is_player_white, board_size = 720 }) => {


### PR DESCRIPTION
In JazzInSea, the standard used for move notation is called JIS algebraic notation. which looks like this:

For vertical moves (piece moves upwards or downwards), the move notation is `a1>2` where `a1` is the starting position and `2` is the target row.

For horizontal moves (piece moves to the left or right side), the move notation is `a1>c` where `a1` is the starting position and `c` is the target column.

For capture moves, use the same notation but replace the `>` character with `x`. The target square is the square the piece ends up on, not the square of the opponent piece.